### PR TITLE
removed nanoid package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "localforage": "^1.10.0",
     "lottie-react": "^2.2.1",
     "moment": "^2.29.3",
-    "nanoid": "^3.3.4",
     "react": "^18.1.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "^18.1.0",

--- a/src/components/Dashboard/QuickAddClient.js
+++ b/src/components/Dashboard/QuickAddClient.js
@@ -3,7 +3,7 @@ import React, { useState, useCallback, useMemo, useEffect } from "react";
 import Skeleton from "react-loading-skeleton";
 import { toast } from "react-toastify";
 import { useDispatch, useSelector } from "react-redux";
-import { nanoid } from "nanoid";
+import { nanoid } from "@reduxjs/toolkit";
 import Button from "../Button/Button";
 import ImageUpload from "../Common/ImageUpload";
 import SectionTitle from "../Common/SectionTitle";

--- a/src/components/Product/QuickAddProduct.js
+++ b/src/components/Product/QuickAddProduct.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo, useEffect } from "react";
 import Skeleton from "react-loading-skeleton";
 import { toast } from "react-toastify";
 import { useDispatch, useSelector } from "react-redux";
-import { nanoid } from "nanoid";
+import { nanoid } from "@reduxjs/toolkit";
 import Button from "../Button/Button";
 import ImageUpload from "../Common/ImageUpload";
 import SectionTitle from "../Common/SectionTitle";

--- a/src/pages/invoices/InvoiceDetailScreen.js
+++ b/src/pages/invoices/InvoiceDetailScreen.js
@@ -38,7 +38,7 @@ import Button from "../../components/Button/Button";
 import ClientPlusIcon from "../../components/Icons/ClientPlusIcon";
 import InvoiceIcon from "../../components/Icons/InvoiceIcon";
 import PlusCircleIcon from "../../components/Icons/PlusCircleIcon";
-import { nanoid } from "nanoid";
+import { nanoid } from "@reduxjs/toolkit";
 import DeleteIcon from "../../components/Icons/DeleteIcon";
 import {
   getSelectedProduct,

--- a/src/store/clientSlice.js
+++ b/src/store/clientSlice.js
@@ -1,6 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit";
 import localforage from "localforage";
-import { nanoid } from "nanoid";
+import { nanoid } from "@reduxjs/toolkit";
 import { CLIENTS_KEY, CLIENT_FORM_KEY } from "../constants/localKeys";
 
 const initialState = {

--- a/src/store/productSlice.js
+++ b/src/store/productSlice.js
@@ -1,6 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit";
 import localforage from "localforage";
-import { nanoid } from "nanoid";
+import { nanoid } from "@reduxjs/toolkit";
 import { PRODUCTS_KEY, PRODUCT_FORM_KEY } from "../constants/localKeys";
 
 const initialState = {


### PR DESCRIPTION
nanoid is a dependncy in @redux-toolkit and can be imported from it, so we dont need to add again.  